### PR TITLE
Fix to team 4661

### DIFF
--- a/data/teamInfo.js
+++ b/data/teamInfo.js
@@ -18066,8 +18066,8 @@ var teamInfo=[
     {
      team_number: 4661,
      rookie_year: 2013,
-             lat: 0.000,
-             lng: 0.000,
+             lat: 31.888,
+             lng: 34.905,
          website: "http://www.firstinspires.org/",
         nickname: "The Red Pirates",
            motto: "",


### PR DESCRIPTION
Due to an extraneous entry in geo_cache, team 4661 wound up in the Gulf of Guinea (lat=0, lon=0) instead of Israel